### PR TITLE
RLMDB 40: Agent Model Switcher UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,12 +8,16 @@ import { v4 as uuidv4 } from "uuid";
 import { useAuth } from "react-oidc-context";
 import LoginCelebration from "./components/LoginCelebration";
 import ConfirmSignOut from "./components/ConfirmSignOut";
+import EngineSwitcher from "./components/EngineSwitcher";
 
 export default function App() {
   const [darkMode, setDarkMode] = useState<boolean>(false);
   useEffect(() => {
     document.documentElement.classList.toggle("dark", darkMode);
   }, [darkMode]);
+
+  const [engine, setEngine] = useState<"openai" | "bedrock">("openai");
+
 
   // ---------- AUTH ----------
   const auth = useAuth();
@@ -99,6 +103,8 @@ export default function App() {
         </h1>
 
         <div className="flex items-center gap-4">
+
+           <EngineSwitcher value={engine} onChange={setEngine} /> {/* NEW */}
           <button
             onClick={() => setDarkMode(!darkMode)}
             className="text-sm px-3 py-1 rounded-full border dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-100 hover:shadow transition"
@@ -120,9 +126,16 @@ export default function App() {
 
       <main className="flex-1 overflow-y-auto px-4 sm:px-6 py-4">
         <QueryClientProvider client={queryClient}>
-          <ChatWindow />
+          {/* REMOVE this duplicate if it exists */}
+          {/* <ChatWindow /> */}
+
+          {/* KEEP this one, but pass backendImpl */}
+          <ChatWindow
+            backendImpl={engine === "bedrock" ? "bedrock" : "langchain"}
+          />
         </QueryClientProvider>
       </main>
+
     </div>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -126,10 +126,6 @@ export default function App() {
 
       <main className="flex-1 overflow-y-auto px-4 sm:px-6 py-4">
         <QueryClientProvider client={queryClient}>
-          {/* REMOVE this duplicate if it exists */}
-          {/* <ChatWindow /> */}
-
-          {/* KEEP this one, but pass backendImpl */}
           <ChatWindow
             backendImpl={engine === "bedrock" ? "bedrock" : "langchain"}
           />

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -4,6 +4,7 @@ import { AiMessage, Message } from "../models/models";
 import { useBedrock } from "../hooks/useBedrock";
 import { useLangchain } from "../hooks/useLangchain";
 import ChatInput from "./ChatInput";
+import { UserMessage } from "../models/models";
 
 type BackendImpl = "bedrock" | "langchain";
 
@@ -43,12 +44,19 @@ const ChatWindow = ({ backendImpl: backendProp = "bedrock" }: ChatWindowProps) =
     });
   };
 
-  // Hooks (unchanged)
-  const bedrockQuery = useBedrock(lastUserMessage);
-  const langchainQuery = useLangchain(lastUserMessage, { enabled: backendImpl === "langchain" });
+// inside the component, before calling the hooks:
+const bedrockMsg =
+  backendImpl === "bedrock" ? (lastUserMessage as UserMessage | undefined) : undefined;
 
-  // Switch based on selected backend
-  const query = backendImpl === "bedrock" ? bedrockQuery : langchainQuery;
+const langchainMsg =
+  backendImpl === "langchain" ? (lastUserMessage as UserMessage | undefined) : undefined;
+
+// call hooks with a single argument each (no options object)
+const bedrockQuery   = useBedrock(bedrockMsg);
+const langchainQuery = useLangchain(langchainMsg);
+
+// pick the active one
+const query = backendImpl === "bedrock" ? bedrockQuery : langchainQuery;
 
   useEffect(() => {
     if (query.isSuccess && query.data) {

--- a/frontend/src/components/EngineSwitcher.tsx
+++ b/frontend/src/components/EngineSwitcher.tsx
@@ -15,7 +15,7 @@ export default function EngineSwitcher({ value, onChange, className }: Props) {
         value={value}
         onChange={(e) => onChange(e.target.value as "openai" | "bedrock")}
       >
-        <option value="openai">OpenAI / LangChain</option>
+        <option value="openai">OpenAI</option>
         <option value="bedrock">AWS Bedrock</option>
       </select>
     </div>

--- a/frontend/src/components/EngineSwitcher.tsx
+++ b/frontend/src/components/EngineSwitcher.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+type Props = {
+  value: "openai" | "bedrock";
+  onChange: (v: "openai" | "bedrock") => void;
+  className?: string;
+};
+
+export default function EngineSwitcher({ value, onChange, className }: Props) {
+  return (
+    <div className={`flex items-center gap-2 ${className ?? ""}`}>
+      <label className="text-sm text-gray-600 dark:text-gray-300">Engine</label>
+      <select
+        className="border rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-700 dark:border-gray-600 outline-none focus:ring w-44"
+        value={value}
+        onChange={(e) => onChange(e.target.value as "openai" | "bedrock")}
+      >
+        <option value="openai">OpenAI / LangChain</option>
+        <option value="bedrock">AWS Bedrock</option>
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useLangchain.ts
+++ b/frontend/src/hooks/useLangchain.ts
@@ -1,12 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import { ErrorResponse, RAGResponse, UserMessage } from "../models/models";
-import { getBedrockResponse } from "../services/bedrockRagService";
+import { ErrorResponse, RAGResponse, UserMessage, Message } from "../models/models";
+import { getLangchainResponse } from "../services/langchainRagService";
 
-export function useLangchain(message?: UserMessage) {
+export function useLangchain(
+  message?: UserMessage | Message,
+  opts?: { enabled?: boolean }
+) {
+  const enabled = !!message && (opts?.enabled ?? true);
+
   return useQuery<RAGResponse, ErrorResponse>({
-    queryKey: ["bedrock", message],
-    queryFn: () => getBedrockResponse(message!),
-    enabled: !!message,
+    queryKey: ["langchain", (message as any)?.message_id],
+    enabled,
+    queryFn: () => getLangchainResponse(message as UserMessage),
     staleTime: 5 * 60 * 1000,
     retry: 1,
   });

--- a/frontend/src/hooks/useLangchain.ts
+++ b/frontend/src/hooks/useLangchain.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { ErrorResponse, RAGResponse, UserMessage, Message } from "../models/models";
+import type { ErrorResponse, RAGResponse, UserMessage, Message } from "../models/models";
 import { getLangchainResponse } from "../services/langchainRagService";
 
 export function useLangchain(
@@ -9,7 +9,7 @@ export function useLangchain(
   const enabled = !!message && (opts?.enabled ?? true);
 
   return useQuery<RAGResponse, ErrorResponse>({
-    queryKey: ["langchain", (message as any)?.message_id],
+    queryKey: ["langchain", message?.message_id],
     enabled,
     queryFn: () => getLangchainResponse(message as UserMessage),
     staleTime: 5 * 60 * 1000,

--- a/frontend/src/services/langchainRagService.ts
+++ b/frontend/src/services/langchainRagService.ts
@@ -1,0 +1,36 @@
+import { RAGResponse, UserMessage } from "../models/models";
+import { v4 as uuid } from "uuid";
+
+export async function getLangchainResponse(message: UserMessage): Promise<RAGResponse> {
+  // If you don't have a Vite proxy for /api -> 127.0.0.1:8000,
+  // use the full URL: "http://127.0.0.1:8000/api/chat"
+  const res = await fetch("/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({
+      session_id: message.session_id ?? null,
+      messages: [
+        // if you want system priming, include it in server.py; here we just send the user msg
+        { role: "user", content: message.content }
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw { message: `LangChain chat failed: ${res.status}`, details: text } as any;
+  }
+
+  // Server returns { reply, session_id }
+  const data = await res.json() as { reply: string; session_id: string };
+
+  // Adapt to your app-wide RAGResponse shape expected by ChatWindow
+  return {
+    message_id: uuid(),
+    content: data.reply,
+    response_parts: [],         // or split if you want parts
+    session_id: data.session_id,
+    created_at: new Date().toISOString(),
+  };
+}

--- a/frontend/src/services/langchainRagService.ts
+++ b/frontend/src/services/langchainRagService.ts
@@ -1,36 +1,51 @@
-import { RAGResponse, UserMessage } from "../models/models";
+// frontend/src/services/langchainRagService.ts
+import axios, { AxiosError } from "axios";
 import { v4 as uuid } from "uuid";
+import type { RAGResponse, UserMessage } from "../models/models";
 
+
+//Calls the LangChain RAG backend.
+// If you don't have a Vite proxy for /api -> http://127.0.0.1:8000,
+// replace "/api/chat" with "http://127.0.0.1:8000/api/chat".
+ 
 export async function getLangchainResponse(message: UserMessage): Promise<RAGResponse> {
-  // If you don't have a Vite proxy for /api -> 127.0.0.1:8000,
-  // use the full URL: "http://127.0.0.1:8000/api/chat"
-  const res = await fetch("/api/chat", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify({
-      session_id: message.session_id ?? null,
-      messages: [
-        // if you want system priming, include it in server.py; here we just send the user msg
-        { role: "user", content: message.content }
-      ],
-    }),
-  });
+  try {
+    const res = await axios.post<{ reply: string; session_id: string }>(
+      "/api/chat",
+      {
+        session_id: message.session_id ?? null,
+        messages: [
+          // System priming should live server-side; we only send the user message
+          { role: "user", content: message.content },
+        ],
+      },
+      {
+        headers: { "Content-Type": "application/json" },
+        withCredentials: true, // mirrors fetch(..., { credentials: "include" })
+      }
+    );
 
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw { message: `LangChain chat failed: ${res.status}`, details: text } as any;
+    const data = res.data;
+
+    // Adapt to app-wide RAGResponse shape
+    const rag: RAGResponse = {
+      message_id: uuid(),
+      content: data.reply,
+      response_parts: [], // populate if you later chunk the reply
+      session_id: data.session_id,
+      created_at: new Date().toISOString(),
+    };
+
+    return rag;
+  } catch (err) {
+    const e = err as AxiosError;
+    const status = e.response?.status ?? 0;
+    const details =
+      typeof e.response?.data === "string"
+        ? e.response?.data
+        : JSON.stringify(e.response?.data ?? {}, null, 2);
+
+    // keep throw shape similar to your previous code
+    throw { message: `LangChain chat failed: ${status}`, details };
   }
-
-  // Server returns { reply, session_id }
-  const data = await res.json() as { reply: string; session_id: string };
-
-  // Adapt to your app-wide RAGResponse shape expected by ChatWindow
-  return {
-    message_id: uuid(),
-    content: data.reply,
-    response_parts: [],         // or split if you want parts
-    session_id: data.session_id,
-    created_at: new Date().toISOString(),
-  };
 }


### PR DESCRIPTION
## Changes:

- Added backend switcher in App.tsx (EngineSwitcher) to toggle between Bedrock and LangChain/OpenAI backends.
- Updated ChatWindow.tsx to accept a backendImpl prop and correctly pass the selected backend.
- Adjusted ChatWindow so that:
`useBedrock only fires when backendImpl === "bedrock".`
`useLangchain only fires when backendImpl === "langchain".`
- Both hooks remain unconditionally declared (avoids React hook order issues).
- Updated langchainRagService.ts to call the correct backend endpoint (/api/chat) and adapt the server’s { reply, session_id } payload into the app-wide RAGResponse shape.
- Ensured session handling is consistent by mapping the session_id returned from LangChain.
- UI now shows a dropdown in the header (EngineSwitcher) to allow switching between Bedrock and LangChain at runtime.

## Testing Steps:

- Make sure your .env in frontend has the Cognito values configured:
```
VITE_COGNITO_AUTHORITY=https://ragdemon.auth... (your AWS Cognito domain)
```
```
VITE_COGNITO_CLIENT_ID=xxxx (client ID from AWS Cognito)
```

- Run the backend (LangChain service):
```
cd backend/langchain_impl
```
```
poetry install
```
```
poetry env activate
```
`# activate venv as per output, then:``

```
poetry run uvicorn langchain_impl.server:api --reload --app-dir src
```


- Run the frontend:

cd frontend
npm install
npm run dev

- In the app header, select OpenAI/LangChain or Bedrock from the new dropdown.

## Expected Behaviours:

- On Bedrock selection:
- Messages flow through the Bedrock RAG pipeline (no regression to existing behaviour).
On LangChain selection:
- Messages POST to /api/chat on the LangChain backend.
- Responses are adapted to the unified RAGResponse shape and displayed in the chat UI.
Session handling:
- Bedrock and LangChain queries are mutually exclusive (only one active at a time).
- No duplicate queries or errors when switching between engines.
UI/UX:
- Engine dropdown persists during the session.
- Users can toggle between Bedrock and LangChain seamlessly.